### PR TITLE
Mark as LOST goals that are WAITING_FOR_GOAL_ACK and are aged out

### DIFF
--- a/src/actionlib/simple_action_client.py
+++ b/src/actionlib/simple_action_client.py
@@ -219,6 +219,13 @@ class SimpleActionClient:
     def stop_tracking_goal(self):
         self.gh = None
 
+    ## @brief Set timestamp delta for lost goal ack processing
+    ##
+    ## @param goal_ack_timeout Time from goal creation to wait for goal
+    ## ack from connected server.
+    def set_goal_ack_timeout(self, goal_ack_timeout):
+        self.action_client.set_goal_ack_timeout(goal_ack_timeout)
+
     def _handle_transition(self, gh):
         comm_state = gh.get_comm_state()
 


### PR DESCRIPTION
Added a lost_goal_timestamp_delta parameter to ActionClient.

This parameter is used by CommStateMachine for detecting "old" or
"aged out" goals that are in the WAITING_FOR_GOAL_ACK state. These
goals will be marked as LOST.

This change allows for the ActionClient to handle goals that were
sent to an ActionServer, but never received by the Server. E.g. In
the event of a network outage.
