### PR TITLE
Fix missing ros/console include

### DIFF
--- a/include/actionlib/client/simple_client_goal_state.h
+++ b/include/actionlib/client/simple_client_goal_state.h
@@ -36,6 +36,7 @@
 #define ACTIONLIB__CLIENT__SIMPLE_CLIENT_GOAL_STATE_H_
 
 #include <string>
+#include <ros/console.h>
 
 namespace actionlib
 {


### PR DESCRIPTION
Need to include ros/console.h for the ROS_ERROR_NAMED definition.